### PR TITLE
Feat: Added possibility to show advanced add dialog also for torrents added…

### DIFF
--- a/background.js
+++ b/background.js
@@ -41,11 +41,20 @@ const offscreenDocumentManager = {
 };
 offscreenDocumentManager._setupReadyPromise(); // Initial setup
 
-const popAdvancedDialog = (url, targetServer) => {
+let dialogWindow = null;
+const popAdvancedDialog = async (url, targetServer) => {
     console.log("[RTWA Background] Creating advanced dialog. Link URL:", url, "Server ID:", targetServer.id, "Server Name:", targetServer.name);
+
+    if (dialogWindow?.id) {
+        // Make sure existing popups are closed before opening a new one
+        chrome.windows.remove(dialogWindow.id).catch(() => {}); // Silently ignore errors
+        dialogWindow = null;
+    }
+
     const dialogUrl = chrome.runtime.getURL('confirmAdd/confirmAdd.html') +
         `?url=${encodeURIComponent(url || '')}&serverId=${encodeURIComponent(targetServer.id || '')}`;
-    chrome.windows.create({
+
+    dialogWindow = await chrome.windows.create({
         url: dialogUrl,
         type: 'popup',
         width: 600,

--- a/background.js
+++ b/background.js
@@ -41,6 +41,18 @@ const offscreenDocumentManager = {
 };
 offscreenDocumentManager._setupReadyPromise(); // Initial setup
 
+const popAdvancedDialog = (url, targetServer) => {
+    console.log("[RTWA Background] Creating advanced dialog. Link URL:", url, "Server ID:", targetServer.id, "Server Name:", targetServer.name);
+    const dialogUrl = chrome.runtime.getURL('confirmAdd/confirmAdd.html') +
+        `?url=${encodeURIComponent(url || '')}&serverId=${encodeURIComponent(targetServer.id || '')}`;
+    chrome.windows.create({
+        url: dialogUrl,
+        type: 'popup',
+        width: 600,
+        height: 580
+    });
+}
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log("[RTWA Background] Received message:", request); 
 
@@ -122,13 +134,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const { url, server, tags, category, addPaused, selectedFileIndices, totalFileCount } = request.params; 
     addTorrentToClient(url, server, tags, category, addPaused, null, null, selectedFileIndices, totalFileCount); 
     return false; 
-  } else if (request.action === 'addTorrent' && request.url) { 
+  } else if (request.action === 'addTorrent' && request.url) {
     const { url, pageUrl } = request;
     (async () => {
       try {
         const targetServer = await determineTargetServer(pageUrl);
         if (targetServer) {
-          addTorrentToClient(url, targetServer, null, null, null, pageUrl);
+          const { advancedAddDialog } = await chrome.storage.local.get(['advancedAddDialog']);
+          const showAdvancedDialog = ['always', 'catch'].includes(advancedAddDialog);
+          if (showAdvancedDialog) {
+              popAdvancedDialog(url, targetServer);
+          } else {
+              addTorrentToClient(url, targetServer, null, null, null, pageUrl);
+          }
           sendResponse({ status: "Torrent add request sent to background." });
         } else {
           const msg = 'No target server could be determined. Please configure servers in options and select an active one in the popup.';
@@ -639,9 +657,9 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
     }
     console.log(`[RTWA Background] Context menu clicked. Item ID: ${info.menuItemId}, Link URL: ${info.linkUrl}, Page URL: ${info.pageUrl}`);
     console.log(`[RTWA Background] Link type detection: isMagnet=${isMagnet}, isTorrentFile=${isTorrentFile}`);
-    const settings = await chrome.storage.local.get(['showAdvancedAddDialog', 'servers', 'activeServerId', 'enableUrlBasedServerSelection', 'urlToServerMappings']);
-    const showAdvancedDialog = settings.showAdvancedAddDialog || false;
-    console.log("[RTWA Background] showAdvancedAddDialog from storage:", settings.showAdvancedAddDialog, "Effective value:", showAdvancedDialog);
+    const settings = await chrome.storage.local.get(['advancedAddDialog', 'servers', 'activeServerId', 'enableUrlBasedServerSelection', 'urlToServerMappings']);
+    const showAdvancedDialog = ['always', 'manual'].includes(settings.advancedAddDialog);
+    console.log("[RTWA Background] advancedAddDialog from storage:", settings.advancedAddDialog, "Effective value:", showAdvancedDialog);
     let serverForDialog = null; 
     let pageUrlForRules = info.pageUrl; 
     try {
@@ -675,15 +693,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
         return;
     }
     if (showAdvancedDialog) {
-      console.log("[RTWA Background] Creating advanced dialog. Link URL:", info.linkUrl, "Server ID:", serverForDialog.id, "Server Name:", serverForDialog.name);
-      const dialogUrl = chrome.runtime.getURL('confirmAdd/confirmAdd.html') +
-                        `?url=${encodeURIComponent(info.linkUrl || '')}&serverId=${encodeURIComponent(serverForDialog.id || '')}`; 
-      chrome.windows.create({
-        url: dialogUrl,
-        type: 'popup',
-        width: 600, 
-        height: 580 
-      });
+      popAdvancedDialog(info.linkUrl, serverForDialog);
     } else {
       addTorrentToClient(info.linkUrl, serverForDialog, null, null, null, pageUrlForRules); 
     }

--- a/options/options.html
+++ b/options/options.html
@@ -201,8 +201,13 @@
         <h2 class="text-2xl font-semibold mb-4 border-b dark:border-gray-700 pb-2">Other Global Settings</h2>
         <div class="space-y-4">
             <div class="form-group flex items-center space-x-2">
-                <input type="checkbox" id="showAdvancedAddDialogToggle" name="showAdvancedAddDialogToggle" class="h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:bg-gray-700 dark:checked:bg-blue-500">
-                <label for="showAdvancedAddDialogToggle" class="text-sm font-medium text-gray-700 dark:text-gray-300">Show advanced options dialog before adding torrent (via context menu/popup)</label>
+                <label for="advancedAddDialogInput" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Show advanced options dialog before adding torrent:</label>
+                <select id="advancedAddDialogInput" class="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white text-sm">
+                    <option value="never">Never</option>
+                    <option value="always">Always</option>
+                    <option value="manual">Only when added manually (via context menu/popup)</option>
+                    <option value="catch">Only on link/form catching</option>
+                </select>
             </div>
             <div class="form-group flex items-center space-x-2">
                 <input type="checkbox" id="catchFromPageToggle" name="catchFromPageToggle" class="h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:bg-gray-700 dark:checked:bg-blue-500">

--- a/options/options.js
+++ b/options/options.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const showAddServerFormButton = document.getElementById('showAddServerFormButton');
 
     // Global settings elements
-    const showAdvancedAddDialogToggle = document.getElementById('showAdvancedAddDialogToggle');
+    const advancedAddDialogInput = document.getElementById('advancedAddDialogInput');
     const enableUrlBasedServerSelectionToggle = document.getElementById('enableUrlBasedServerSelectionToggle');
     const catchFromPageToggle = document.getElementById('catchFromPageToggle'); 
     const linksFoundIndicatorToggle = document.getElementById('linksFoundIndicatorToggle'); 
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let servers = [];
     let activeServerId = null;
     let globalSettings = {
-        showAdvancedAddDialog: false,
+        advancedAddDialog: 'never',
         enableUrlBasedServerSelection: false,
         catchfrompage: false, 
         linksfoundindicator: false, 
@@ -468,9 +468,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Event Handlers for Global Settings ---
     clientTypeSelect.addEventListener('change', (event) => { toggleClientSpecificFields(event.target.value); });
-    showAdvancedAddDialogToggle.addEventListener('change', () => {
-        globalSettings.showAdvancedAddDialog = showAdvancedAddDialogToggle.checked;
-        chrome.storage.local.set({ showAdvancedAddDialog: globalSettings.showAdvancedAddDialog }, () => { displayFormStatus('Global settings updated.', 'success'); });
+    advancedAddDialogInput.addEventListener('change', () => {
+        globalSettings.advancedAddDialog = advancedAddDialogInput.value || 'never';
+        chrome.storage.local.set({ advancedAddDialog: globalSettings.advancedAddDialog }, () => { displayFormStatus('Global settings updated.', 'success'); });
     });
     catchFromPageToggle.addEventListener('change', () => {
         globalSettings.catchfrompage = catchFromPageToggle.checked;
@@ -525,7 +525,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (!newActiveServerId && newServers.length > 0) newActiveServerId = newServers[0].id;
                     const settingsToSave = {
                         servers: newServers, activeServerId: newActiveServerId,
-                        showAdvancedAddDialog: importedSettings.showAdvancedAddDialog || false,
+                        advancedAddDialog: importedSettings.advancedAddDialog || importedSettings.showAdvancedAddDialog && 'manual' || 'never',  // Migrate showAdvancedAddDialog -> advancedAddDialog
                         enableUrlBasedServerSelection: importedSettings.enableUrlBasedServerSelection || false,
                         urlToServerMappings: importedSettings.urlToServerMappings || [],
                         catchfrompage: importedSettings.catchfrompage || false, 
@@ -553,14 +553,14 @@ document.addEventListener('DOMContentLoaded', () => {
             extensionVersionSpan.textContent = manifest.version;
         }
         chrome.storage.local.get([
-            'servers', 'activeServerId', 'showAdvancedAddDialog', 'enableUrlBasedServerSelection', 
+            'servers', 'activeServerId', 'showAdvancedAddDialog', 'advancedAddDialog', 'enableUrlBasedServerSelection',
             'urlToServerMappings', 'catchfrompage', 'linksfoundindicator', 'linkmatches', 
             'registerDelay', 'enableSoundNotifications', 'trackerUrlRules'
         ], (result) => {
             servers = (result.servers || []).map(s => ({ ...s, clientType: s.clientType || 'qbittorrent', url: s.url || s.qbUrl, username: s.username || s.qbUsername, password: s.password || s.qbPassword, rpcPath: s.rpcPath || (s.clientType === 'transmission' ? '/transmission/rpc' : ''), scgiPath: s.scgiPath || '', askForLabelDirOnPage: s.askForLabelDirOnPage || false }));
             activeServerId = result.activeServerId || (servers.length > 0 ? servers[0].id : null);
-            globalSettings.showAdvancedAddDialog = result.showAdvancedAddDialog || false;
-            showAdvancedAddDialogToggle.checked = globalSettings.showAdvancedAddDialog;
+            globalSettings.advancedAddDialog = (result.advancedAddDialog || result.showAdvancedAddDialog && 'manual' || 'never'); // Migrate showAdvancedAddDialog -> advancedAddDialog
+            advancedAddDialogInput.value = globalSettings.advancedAddDialog;
             globalSettings.enableUrlBasedServerSelection = result.enableUrlBasedServerSelection || false;
             enableUrlBasedServerSelectionToggle.checked = globalSettings.enableUrlBasedServerSelection; 
             urlToServerMappings = result.urlToServerMappings || [];


### PR DESCRIPTION
Added possibility to show advanced add dialog also for torrents added by link-catching.
Replaced setting "showAdvancedAddDialog": <boolean> with "advancedAddDialog": <"never" | "always" | "manual" | "catch">
Migrate setting "showAdvancedAddDialog" true/false -> "advancedAddDialog": "manual"/"never"