### PR TITLE
Fix sound notifications by removing ES module import from offscreen document

### DIFF
--- a/offscreen_audio.js
+++ b/offscreen_audio.js
@@ -1,12 +1,22 @@
-import { debug } from './debug';
+// Simplified debug system for offscreen document (no ES modules)
+const debug = {
+  enabled: true,
+  log: (...args) => debug.enabled ? console.log(...args) : void 0,
+  warn: (...args) => debug.enabled ? console.warn(...args) : void 0,
+  error: (...args) => debug.enabled ? console.error(...args) : void 0,
+  setEnabled: (enabled) => { debug.enabled = enabled; }
+};
 
 try {
   chrome.storage.local.get('bgDebugEnabled', (result) => {
     const { bgDebugEnabled } = result;
-    debug.setEnabled(bgDebugEnabled);
+    // Enable if bgDebugEnabled is true or contains 'log', 'warn', or 'error'
+    const shouldEnable = bgDebugEnabled === true ||
+      (Array.isArray(bgDebugEnabled) && bgDebugEnabled.length > 0);
+    debug.setEnabled(shouldEnable);
   });
 } catch (error) {
-    debug.setEnabled(true);
+  debug.setEnabled(true);
 }
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -29,9 +39,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
     return true; // Indicates async response
   }
-  // Acknowledge other messages if needed, or just return false for sync.
-  // sendResponse({ success: false, error: 'Unknown action or missing soundFile' });
-  return false; 
+  return false;
 });
 
 // Notify the service worker that the offscreen document is ready


### PR DESCRIPTION
I wasn't getting notification sounds anymore so I had Claude Sonnet 4 help me debug it and create this PR

## Problem
Sound notifications were not working due to an ES module import error in the offscreen document. Users with sound notifications enabled would not hear audio when torrents were added successfully or failed.

**Error:** `Cannot use import statement outside a module` in `offscreen_audio.js`

## Root Cause
The `offscreen_audio.js` file used `import { debug } from './debug'` but the offscreen document context doesn't properly support ES modules, causing the script to fail to load.

## Solution
- Replaced the ES module import with an inline debug system
- Maintains all existing debug functionality  
- Preserves compatibility with the `bgDebugEnabled` setting
- No breaking changes to the API

## Testing
- ✅ Sound notifications now work correctly for torrent additions
- ✅ Both success and failure sounds play as expected  
- ✅ Verified with real torrent file downloads
- ✅ Extension rebuilds and loads without errors

## Files Changed
- `offscreen_audio.js` - Removed ES import, added inline debug system

This is a minimal, targeted fix that resolves the issue without affecting any other functionality.