### PR TITLE
Fix category assignment for context-menu directory adds

### DIFF
--- a/background.js
+++ b/background.js
@@ -1234,6 +1234,32 @@ function parseLabelDirectoryMap(rawMapping) {
     }, {});
 }
 
+function findUniqueCategoryForDirectory(labelDirectoryMap, downloadDir) {
+  if (
+    !labelDirectoryMap ||
+    typeof labelDirectoryMap !== "object" ||
+    downloadDir === null ||
+    downloadDir === undefined
+  ) {
+    return null;
+  }
+
+  const normalizedDownloadDir = String(downloadDir).trim();
+  if (!normalizedDownloadDir) {
+    return null;
+  }
+
+  const matchingCategories = Object.entries(labelDirectoryMap)
+    .filter(
+      ([, directory]) =>
+        typeof directory === "string" &&
+        directory.trim() === normalizedDownloadDir
+    )
+    .map(([category]) => category);
+
+  return matchingCategories.length === 1 ? matchingCategories[0] : null;
+}
+
 function looksLikeTorrentUrl(url) {
   if (!url) return false;
   const lower = String(url).toLowerCase();
@@ -2367,11 +2393,38 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (showAdvancedDialog) {
     popAdvancedDialog(linkUrl, selectedServer);
   } else {
+    const labelDirectoryMap = parseLabelDirectoryMap(
+      selectedServer.labelDirectoryMap
+    );
+    const inferredCategory = findUniqueCategoryForDirectory(
+      labelDirectoryMap,
+      downloadDir
+    );
+
+    if (inferredCategory) {
+      debug.log(
+        "[ART Background] Inferred a unique category for the selected context-menu directory."
+      );
+    } else if (downloadDir) {
+      const normalizedDownloadDir = downloadDir.trim();
+      const matchingDirectoryCount = Object.values(labelDirectoryMap).filter(
+        (directory) =>
+          typeof directory === "string" &&
+          directory.trim() === normalizedDownloadDir
+      ).length;
+
+      if (matchingDirectoryCount > 1) {
+        debug.log(
+          "[ART Background] Multiple categories map to the selected context-menu directory; category inference skipped."
+        );
+      }
+    }
+
     addTorrentToClient(
       linkUrl,
       selectedServer,
       null,
-      null,
+      inferredCategory,
       null,
       info.pageUrl,
       downloadDir


### PR DESCRIPTION
## Problem

When a user chooses a configured download directory from the right-click context menu, qBittorrent saves the torrent in the correct directory but does not assign the category mapped to that directory.

## Root cause

The context-menu handler passes the selected directory to `addTorrentToClient()`, but passes `null` for the category. The existing label-to-directory mapping supports category-to-directory lookups only. Reversing that mapping also requires care because more than one category can point to the same directory.

## Fix

This change adds a pure reverse-lookup helper and uses it only for direct context-menu directory additions. It compares the selected directory with mapped directory values exactly after trimming surrounding whitespace, then supplies the category only when one unique mapping matches.

## Behavior and ambiguity handling

- One matching category is inferred and passed with the selected directory.
- No matching category preserves the existing behavior.
- Multiple categories mapped to the same directory are treated as ambiguous, so the extension does not guess.
- Debug logging reports successful inference and skipped ambiguous inference without logging category names or directory values.
- Other add paths and explicitly supplied categories are unchanged.

## Validation

- `bun install --frozen-lockfile` using Bun 1.3.14
- Focused helper checks covering unique, missing, ambiguous, explicit-category, and no-directory cases
- Manual Brave/qBittorrent integration test: selecting a configured context-menu directory preserved the selected directory and assigned its uniquely mapped category
- `bun run build:firefox`
- `node scripts/verify-dist-background.js`
- `git diff --check`
- `bun run build` completed the production webpack build and background verification, then exited at the final signed-CRX packaging step because the maintainer-only `private.pem` is not present in the fork checkout. Generated ZIP/hash changes were restored and are not included.

## Manual test plan

1. Configure two categories, two download directories, and a unique category-to-directory mapping for each directory.
2. With the advanced add dialog disabled, right-click a torrent link and select one configured directory.
3. Confirm qBittorrent uses both the selected directory and its uniquely mapped category.
4. Map two categories to the same directory, select it again, and confirm the extension does not infer either category.
5. Select an unmapped directory and a context-menu item without a directory, confirming existing category and directory behavior is preserved.
